### PR TITLE
feat: 대기열 진입 시점 타임스탬프 일관성 유지 및 기존 customerId 재사용\n\n- QueueController…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,4 @@ out/
 /.nb-gradle/
 
 ### VS Code ###
-.vscode/
+.vscode/thehyundai-sample_analysis.md

--- a/src/main/java/com/winten/greenlight/prototype/core/api/controller/queue/QueueController.java
+++ b/src/main/java/com/winten/greenlight/prototype/core/api/controller/queue/QueueController.java
@@ -38,6 +38,7 @@ public class QueueController {
         if (request.getActionId() == null) {
             return Mono.error(new CoreException(ErrorType.BAD_REQUEST, "actionId is required."));
         }
-        return queueApplicationService.checkOrEnterQueue(request.getActionId(), request.getDestinationUrl(), greenlightToken, requestParams);
+        long entryTimestamp = System.currentTimeMillis();
+        return queueApplicationService.checkOrEnterQueue(request.getActionId(), request.getDestinationUrl(), greenlightToken, requestParams, entryTimestamp);
     }
 }

--- a/src/main/java/com/winten/greenlight/prototype/core/domain/queue/QueueDomainService.java
+++ b/src/main/java/com/winten/greenlight/prototype/core/domain/queue/QueueDomainService.java
@@ -49,9 +49,9 @@ public class QueueDomainService {
      * @param status 대기열의 상태 (WAITING or READY)
      * @return Mono<Long> 대기열에 추가된 후의 순번 (0부터 시작)
      */
-    public Mono<Long> addUserToQueue(Long actionGroupId, String customerId, WaitStatus status) {
+    public Mono<Long> addUserToQueue(Long actionGroupId, String customerId, WaitStatus status, long timestamp) {
         String queueKey = redisKeyBuilder.queue(actionGroupId, status);
-        return queueRepository.add(queueKey, customerId, System.currentTimeMillis());
+        return queueRepository.add(queueKey, customerId, timestamp);
     }
 
     /**ㄷ

--- a/src/main/java/com/winten/greenlight/prototype/core/domain/token/TokenDomainService.java
+++ b/src/main/java/com/winten/greenlight/prototype/core/domain/token/TokenDomainService.java
@@ -29,13 +29,13 @@ public class TokenDomainService {
      * @param status     토큰의 초기 상태 (예: "WAITING", "ALLOWED")
      * @return Mono<String> 발급된 JWT 토큰 문자열
      */
-    public Mono<String> issueToken(String customerId, Action action, String status, String landingDestinationUrl) {
-        var entry = CustomerEntry.builder()
+    public Mono<String> issueToken(String customerId, Action action, String status, String landingDestinationUrl, long timestamp) {
+                var entry = CustomerEntry.builder()
                 .actionGroupId(action.getActionGroupId())
                 .actionId(action.getId())
                 .customerId(customerId)
-                .landingDestinationUrl(landingDestinationUrl) // 이 줄을 추가합니다.
-                .timestamp(System.currentTimeMillis())
+                .landingDestinationUrl(landingDestinationUrl)
+                .timestamp(timestamp)
                 .build();
         return Mono.just(jwtUtil.generateToken(entry));
         // 시나리오 1: 기존 토큰을 찾아 만료시키는 로직


### PR DESCRIPTION
…: API 최초 진입 시점의 타임스탬프를 생성하여 하위 서비스로 전달하도록 수정함.\n- QueueApplicationService:\n    - checkOrEnterQueue 메서드에 타임스탬프 인자를 추가하고, EntryTicket 생성 및 handleNewEntry 호출 시 해당 타임스탬프를 사용하도록 변경함.\n    - 토큰이 존재하지만 actionId가 다른 경우, 새로운 customerId를 채번하는 대신 기존 토큰의 customerId를 재사용하도록 수정함.\n- TokenDomainService: issueToken 메서드에 타임스탬프 인자를 추가하고, JWT 생성 시 해당 타임스탬프를 사용하도록 변경함.\n- QueueDomainService: addUserToQueue 메서드에 타임스탬프 인자를 추가하고, Redis Sorted Set에 사용자 추가 시 해당 타임스탬프를 score로 사용하도록 변경함.\n\n이를 통해 대기열 진입 시점의 타임스탬프 일관성을 유지하고, 불필요한 customerId 재채번을 방지함.